### PR TITLE
Update URL for Fira Mono

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Attention
 
 1. [Read this first](https://github.com/morhetz/gruvbox/wiki/Terminal-specific)
 2. Typeface from gallery is [Fantasque Sans Mono](https://github.com/belluzj/fantasque-sans)
-3. Typeface from screenshots below is [Fira Mono](http://www.carrois.com/fira-4-1/)
+3. Typeface from screenshots below is [Fira Mono](https://mozilla.github.io/Fira/)
 
 Screenshots
 -----------


### PR DESCRIPTION
Original link 404's now. Uses Mozilla link which leads to their repo with all Fira family fonts: https://github.com/mozilla/Fira